### PR TITLE
docs: rewrite README in canonical structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,58 +5,82 @@
 [![SPM Compatible](https://img.shields.io/badge/SPM-compatible-brightgreen.svg)](https://swift.org/package-manager/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Lock screen orientation per-view in SwiftUI. No UIKit subclassing, no hacks.**
+Per-view orientation locking for SwiftUI apps. Attach one modifier to a view and it locks the app to the orientations you specify while that view is on screen.
 
 ```swift
 Text("This view stays portrait")
     .supportedInterfaceOrientations(.portrait)
 ```
 
-That's it. The view locks to portrait. Navigate away, it unlocks. Conflicting constraints across multiple views? Handled automatically.
+## Table of Contents
 
-## The Problem
+- [Background](#background)
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Project Structure](#project-structure)
+- [Contributing](#contributing)
+- [License](#license)
 
-SwiftUI has no native way to lock orientation for specific views. You either lock the entire app in Info.plist, or dive into UIKit lifecycle callbacks scattered across AppDelegate, SceneDelegate, and view controllers.
+## Background
 
-This package gives you a single view modifier that just works.
+SwiftUI has no built-in way to control orientation per view. Your options are to lock the whole app through `Info.plist`, or to manage `application(_:supportedInterfaceOrientationsFor:)` by hand and track which screen is visible across the UIKit lifecycle.
+
+This package replaces that bookkeeping with a single view modifier. Each view registers its allowed orientations when it appears and removes them when it disappears. A shared `InterfaceOrientationManager` holds the registry, computes the intersection of every active constraint, and asks the system to re-evaluate the supported orientations. When two visible views ask for orientations that don't overlap, the manager falls back to your app defaults instead of returning an empty mask.
+
+## Features
+
+- One modifier, `.supportedInterfaceOrientations(_:)`, applied directly to any view.
+- Constraints register on `onAppear` and clear on `onDisappear`, so navigating away restores the previous orientation.
+- Multiple visible views resolve to the intersection of their masks; an empty intersection falls back to your defaults.
+- Defaults read from `UISupportedInterfaceOrientations` in `Info.plist`, or set them explicitly through `Configuration`.
+- Updates supported orientations through `setNeedsUpdateOfSupportedInterfaceOrientations()` on iOS 16+, falling back to `attemptRotationToDeviceOrientation()` on earlier versions.
+- `@MainActor`-isolated manager built for the Swift 6 language mode.
 
 ## Installation
 
-### Swift Package Manager
+### Xcode
+
+1. Open **File → Add Package Dependencies…**
+2. Enter the URL: `https://github.com/ivan-magda/swiftui-interface-orientation.git`
+3. Choose the `SwiftUIInterfaceOrientation` library and add it to your target.
+
+### Package.swift
+
+Add the package to your dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/ivan-magda/swiftui-interface-orientation.git", from: "1.2.0")
+    .package(
+        url: "https://github.com/ivan-magda/swiftui-interface-orientation.git",
+        from: "1.2.0"
+    )
 ]
 ```
 
-Or in Xcode: **File → Add Packages** → paste the URL above.
-
-## Quick Start
-
-### 1. Configure the manager (once, at app launch)
+Then add the product to your target:
 
 ```swift
-import SwiftUIInterfaceOrientation
-
-@main
-struct MyApp: App {
-    init() {
-        InterfaceOrientationManager.configure()
-    }
-
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
-    }
-}
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(
+            name: "SwiftUIInterfaceOrientation",
+            package: "swiftui-interface-orientation"
+        )
+    ]
+)
 ```
 
-### 2. Wire up iOS orientation callbacks
+### App-level setup
+
+The manager resolves orientations, but iOS only asks for them through your app delegate. Implement `application(_:supportedInterfaceOrientationsFor:)` and return `InterfaceOrientationManager.shared.supportedInterfaceOrientations`. Without this hook the modifier has no effect.
 
 ```swift
-class OrientationDelegate: NSObject, UIApplicationDelegate {
+import SwiftUI
+import SwiftUIInterfaceOrientation
+
+class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
         _ application: UIApplication,
         supportedInterfaceOrientationsFor window: UIWindow?
@@ -67,11 +91,7 @@ class OrientationDelegate: NSObject, UIApplicationDelegate {
 
 @main
 struct MyApp: App {
-    @UIApplicationDelegateAdaptor(OrientationDelegate.self) var delegate
-
-    init() {
-        InterfaceOrientationManager.configure()
-    }
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
         WindowGroup {
@@ -81,77 +101,117 @@ struct MyApp: App {
 }
 ```
 
-### 3. Lock any view to specific orientations
+The manager reads its defaults from the `UISupportedInterfaceOrientations` key in your app's `Info.plist`. To set defaults in code instead, see [Custom defaults](#custom-defaults).
+
+## Usage
+
+### Lock a single view
+
+Apply the modifier to any view. The constraint applies while the view is visible and clears when it leaves the screen.
 
 ```swift
+import SwiftUI
+import SwiftUIInterfaceOrientation
+
 struct PortraitOnlyView: View {
     var body: some View {
         Text("Locked to portrait")
             .supportedInterfaceOrientations(.portrait)
     }
 }
+```
 
-struct LandscapeOnlyView: View {
+### Navigation
+
+Each destination declares its own orientations. The constraint registers when the destination appears and clears when you navigate back.
+
+```swift
+struct ContentView: View {
     var body: some View {
-        VideoPlayer(player: player)
-            .supportedInterfaceOrientations([.landscapeLeft, .landscapeRight])
+        NavigationStack { // NavigationView on iOS 14-15
+            List {
+                NavigationLink("Portrait screen") {
+                    Text("Portrait only")
+                        .supportedInterfaceOrientations(.portrait)
+                }
+
+                NavigationLink("Landscape screen") {
+                    Text("Landscape only")
+                        .supportedInterfaceOrientations(.landscape)
+                }
+            }
+        }
     }
 }
 ```
 
-## How It Works
+### Allow all but upside down
 
-The package uses a centralized `InterfaceOrientationManager` that tracks orientation constraints from all active views:
-
-1. When a view with `.supportedInterfaceOrientations()` appears, it registers its constraint
-2. When the view disappears, the constraint is removed
-3. The manager computes the intersection of all active constraints
-4. If constraints conflict (intersection is empty), it falls back to your app's defaults from Info.plist
-
-This means nested views with different constraints "just work"—the most restrictive common orientation wins.
-
-## API
-
-### View Modifier
+A common choice for iPhone apps:
 
 ```swift
-func supportedInterfaceOrientations(_ orientations: UIInterfaceOrientationMask) -> some View
+ContentView()
+    .supportedInterfaceOrientations(.allButUpsideDown)
 ```
 
-### Configuration
+### Clear a constraint
+
+Pass `nil` or an empty mask to remove this view's constraint and let the defaults apply.
 
 ```swift
-// Use defaults from Info.plist
-InterfaceOrientationManager.configure()
-
-// Or specify custom defaults
-InterfaceOrientationManager.configure(
-    configuration: .init(defaultOrientations: .portrait)
-)
+SomeView()
+    .supportedInterfaceOrientations(isLocked ? .portrait : nil)
 ```
 
-### Orientation Masks
+### Custom defaults
+
+By default the manager reads `UISupportedInterfaceOrientations` from `Info.plist`. To supply defaults in code, call `configure(configuration:)` before anything accesses `InterfaceOrientationManager.shared`. The call asserts if the manager has already initialized, so place it at the start of your launch sequence, such as in `application(_:didFinishLaunchingWithOptions:)`.
 
 ```swift
-.portrait           // Portrait only
-.landscapeLeft      // Landscape, home button on right
-.landscapeRight     // Landscape, home button on left
-.portraitUpsideDown // Upside down (iPad only effectively)
-.landscape          // Both landscape orientations
-.all                // All orientations
-.allButUpsideDown   // All except upside down
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        InterfaceOrientationManager.configure(
+            configuration: .init(defaultOrientations: .portrait)
+        )
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        supportedInterfaceOrientationsFor window: UIWindow?
+    ) -> UIInterfaceOrientationMask {
+        InterfaceOrientationManager.shared.supportedInterfaceOrientations
+    }
+}
 ```
 
-## Requirements
+`Configuration.fromInfoPlist()` is the default and reproduces the automatic behavior.
 
-- iOS 14.0+
-- Swift 6
-- Xcode 16.0+
+## Project Structure
 
-## License
-
-MIT License. See [LICENSE](LICENSE) for details.
+```
+Sources/SwiftUIInterfaceOrientation/
+├── InterfaceOrientationManager.swift   // Registry, resolution, and Configuration
+├── View+InterfaceOrientation.swift     // The .supportedInterfaceOrientations(_:) modifier
+└── MainBundleInfo.swift                // Reads UISupportedInterfaceOrientations from Info.plist
+```
 
 ## Contributing
 
-Issues and PRs welcome.
+Issues and pull requests are welcome. The package builds with `swift build`, and the test suite runs against an iOS simulator:
+
+```bash
+xcodebuild test \
+  -scheme SwiftUIInterfaceOrientation \
+  -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" \
+  -configuration Debug
+```
+
+Lint with `swiftlint --strict` before opening a pull request.
+
+## License
+
+Released under the MIT License. See [LICENSE](LICENSE) for the full text.


### PR DESCRIPTION
Rewrites the README into the canonical documentation structure, grounded in the actual source rather than the previous freeform layout.

## What changed
- Title + tagline, Table of Contents, Background, Features, Installation, Usage, Project Structure, Contributing, License — in canonical order.
- Installation documents both the Xcode flow and a `Package.swift` snippet using `.product(name: "SwiftUIInterfaceOrientation", package: "swiftui-interface-orientation")`, since the product name and the repo/package name differ.
- Documents the required app-level hook: implementing `application(_:supportedInterfaceOrientationsFor:)` in the `UIApplicationDelegate` and returning `InterfaceOrientationManager.shared.supportedInterfaceOrientations`. The modifier has no effect without it.
- Usage examples (single view, navigation, `.allButUpsideDown`, clearing with `nil`, custom defaults via `configure(configuration:)`) are taken from the real API.
- `from: "1.2.0"` verified against the latest tag and GitHub release.
- Existing badges preserved.

## Omitted sections
- **Philosophy** — no distinct design manifesto in the source beyond the background/resolution behavior, which is covered under Background.